### PR TITLE
Fix bug that camera may use destroyed surface to preview.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.yoojia.zxing" >
 
-    <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.camera.autofocus" />
+
 
     <application
         android:allowBackup="true"

--- a/zxing/src/main/AndroidManifest.xml
+++ b/zxing/src/main/AndroidManifest.xml
@@ -1,1 +1,9 @@
-<manifest package="com.github.yoojia.qrcode"/>
+<manifest
+    package="com.github.yoojia.qrcode"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.CAMERA"/>
+
+    <uses-feature android:name="android.hardware.camera"/>
+    <uses-feature android:name="android.hardware.camera.autofocus"/>
+</manifest>


### PR DESCRIPTION
修复一个问题：
当应用程序进入后台后，surface可能会被回收，而原有的设置preview的调用顺序不正确，导入传入一个NULL surface而无法进行预览的问题。